### PR TITLE
Cleaning .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,53 +1,16 @@
+# macOS
+.DS_Store
+
 # Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
-## Build generated
-build/
-DerivedData/
-
-## Various settings
->>>>>>> e0f9954e904c9885e95959d121d5d9bda46c85c1
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
 xcuserdata/
-<<<<<<< HEAD
+*.xcscmblueprint
 *.xccheckout
-profile
-*.moved-aside
-DerivedData
-*.hmap
-*.ipa
+
+# AppCode
+.idea
 
 # Bundler
 .bundle
-
-Carthage
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-#
-# Note: if you ignore the Pods directory, make sure to uncomment
-# `pod install` in .travis.yml
-#
-# Pods/
-=======
-
-## Other
-*.moved-aside
-*.xcuserstate
-
-## Obj-C/Swift specific
-*.hmap
-*.ipa
-*.dSYM.zip
-*.dSYM
 
 ## Playgrounds
 timeline.xctimeline
@@ -57,7 +20,6 @@ playground.xcworkspace
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
-.build/
 
 # CocoaPods
 #
@@ -71,8 +33,7 @@ playground.xcworkspace
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
-
-Carthage/Build
+Carthage
 
 # fastlane
 #
@@ -80,7 +41,6 @@ Carthage/Build
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
-
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots


### PR DESCRIPTION
Note that I've participated to the current GitHub reference of .gitignore for Xcode: https://github.com/github/gitignore/blob/master/Global/Xcode.gitignore, so I got some experience with this file.

Details of this commit regarding .gitignore:
* Solve the incomplete merge (>>>>>>>, <<<<<<<, ======= and the lines in-between)
* Removed obsolete Xcode 4 and older specific files (default.* and their non-default, build, DerivedData, etc.)
* Removed some more unrelated files, *.hmap and *.ipa, because we have no script building those
* Added missing *.xcscmblueprint for Xcode 8 (OK, not strictly needed nowadays of Xcode 9+, but in that case you may remove *.xccheckout too)
* Added .DS_Store because some people are accidentally committing those files (see e8f33c7e75bb486c27081895404510db7c9f67f6)
* Added .idea/ because it's a popular IDE: https://www.jetbrains.com/objc/
* factoring Carthage and Carthage/Build
